### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/cmreshandler/cmreshandler.py
+++ b/cmreshandler/cmreshandler.py
@@ -145,7 +145,7 @@ class CMRESHandler(logging.Handler):
         """ Returns elasticearch index name
         :return: A srting containing the elasticsearch indexname used which should include the date.
         """
-        return "%s-%s" % (self.es_index_name, datetime.datetime.now().strftime('%Y.%m.%d'))
+        return "{0!s}-{1!s}".format(self.es_index_name, datetime.datetime.now().strftime('%Y.%m.%d'))
 
     @staticmethod
     def __get_es_datetime_str(timestamp):
@@ -155,7 +155,7 @@ class CMRESHandler(logging.Handler):
         :return: A string valid for elasticsearch time record
         """
         t = datetime.datetime.utcfromtimestamp(timestamp)
-        return "%s.%03.dZ" % (t.strftime('%Y-%m-%dT%H:%M:%S'), int(t.microsecond / 1000))
+        return "{0!s}.{1:03d}Z".format(t.strftime('%Y-%m-%dT%H:%M:%S'), int(t.microsecond / 1000))
 
     def flush(self):
         """ Flushes the buffer into ES

--- a/tests/test_cmreshandler.py
+++ b/tests/test_cmreshandler.py
@@ -34,7 +34,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
 
         es_test_server_is_up = handler.test_es_source()
-        self.log.info("ES services status is:  %s" % es_test_server_is_up)
+        self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
         self.assertEquals(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
@@ -57,7 +57,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
 
         es_test_server_is_up = handler.test_es_source()
-        self.log.info("ES services status is:  %s" % es_test_server_is_up)
+        self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
         self.assertEquals(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
@@ -81,7 +81,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
 
         es_test_server_is_up = handler.test_es_source()
-        self.log.info("ES services status is:  %s" % es_test_server_is_up)
+        self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
         self.assertEquals(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
@@ -103,7 +103,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
         log.setLevel(logging.DEBUG)
         log.addHandler(handler)
         for i in xrange(1000):
-            log.info("Logging line %d" % i, extra={'LineNum': i})
+            log.info("Logging line {0:d}".format(i), extra={'LineNum': i})
         time.sleep(0.5)
         self.assertEquals(0, len(handler._buffer))
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:cmanaha:python-elasticsearch-logger?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:cmanaha:python-elasticsearch-logger?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)