### PR TITLE
Remove trailing comma

### DIFF
--- a/cmreshandler/cmreshandler.py
+++ b/cmreshandler/cmreshandler.py
@@ -89,7 +89,7 @@ class CMRESHandler(logging.Handler):
         logging.Handler.__init__(self)
 
         self.hosts = hosts
-        self.auth_details = auth_details,
+        self.auth_details = auth_details
         self.auth_type = auth_type
         self.use_ssl = use_ssl
         self.verify_certs = verify_ssl


### PR DESCRIPTION
When using `BASIC_AUTH` we revived an error associated with `auth_details` being set to `(('username', 'password'),)` instead of `('username', 'password')`. We determined that it was the trailing comma that was to blame.