### PR TITLE
Refactor ver1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ var/
 .installed.cfg
 *.egg
 
+pylint.txt
+coverage.xml
+pylint_*
+.pylint.d/
+.sonar/
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 env:
  - TOXENV=py27
+ - TOXENV=py35
 
 install:
  - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
-env:
- - TOXENV=py27
- - TOXENV=py35
+python:
+  - "2.7"
+  - "3.6"
 
 install:
  - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 
 install:
- - pip install tox
+ - pip install tox-travis
  - pip install codecov
  - mkdir /tmp/elasticsearch
  - wget -O - http://s3-eu-west-1.amazonaws.com/build.eu-west-1.elastic.co/origin/2.0/nightly/JDK7/elasticsearch-latest-SNAPSHOT.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1

--- a/README.rst
+++ b/README.rst
@@ -25,17 +25,25 @@ Install using pip::
 
 Requirements
 ============
+__python 2__
 This library requires the following dependencies
- - requests
- - requests-kerberos
  - elasticsearch
+ - requests
  - enum
+
+__python 3__
+This library requires the following dependencies
+ - elasticsearch
+ - requests
+
+Additionally, the package support optionally kerberos authentication by adding the following dependecy
+ - requests-kerberos
 
 Using the handler in  your program
 ==================================
 To initialise and create the handler, just add the handler to your logger as follow ::
 
-    import CMRESHandler
+    from cmrlogging.handlers import CMRESHandler
     handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="my_python_index")
@@ -45,7 +53,7 @@ To initialise and create the handler, just add the handler to your logger as fol
 
 You can add fields upon initialisation, providing more data of the execution context ::
 
-    import CMRESHandler
+    from cmrlogging.handlers import CMRESHandler
     handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="my_python_index",
@@ -112,7 +120,7 @@ they can be plotted on Kibana, or the SQL statements that Django executed. ::
             },
             'elasticsearch': {
                 'level': 'DEBUG',
-                'class': 'cmreshandler.cmreshandler.CMRESHandler',
+                'class': 'cmrlogging.handlers.CMRESHandler',
                 'hosts': [{'host': 'localhost', 'port': 9200}],
                 'es_index_name': 'my_python_app',
                 'es_additional_fields': {'App': 'Test', 'Environment': 'Dev'},

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,10 @@ The constructors takes the following parameters:
  - flush_frequency_in_sec: A float representing how often and when the buffer will be flushed
  - es_index_name: A string with the prefix of the elasticsearch index that will be created. Note a date with
    YYYY.MM.dd, ``python_logger`` used by default
+ - index_name_frequency: The frequency to use as part of the index naming. Currently supports
+   CMRESHandler.IndexNameFrequency.DAILY, CMRESHandler.IndexNameFrequency.WEEKLY,
+   CMRESHandler.IndexNameFrequency.MONTHLY, CMRESHandler.IndexNameFrequency.YEARLY by default the daily rotation
+   is used
  - es_doc_type: A string with the name of the document type that will be used ``python_log`` used by default
  - es_additional_fields: A dictionary with all the additional fields that you would like to add to the logs
 

--- a/README.rst
+++ b/README.rst
@@ -23,20 +23,22 @@ Install using pip::
 
     pip install CMRESHandler
 
-Requirements
-============
- * python 2
+Requirements Python 2
+=====================
 This library requires the following dependencies
  - elasticsearch
  - requests
  - enum
 
 
- * python 3
+Requirements Python 3
+=====================
 This library requires the following dependencies
  - elasticsearch
  - requests
 
+Additional requirements for Kerberos support
+============================================
 Additionally, the package support optionally kerberos authentication by adding the following dependecy
  - requests-kerberos
 

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ This library requires the following dependencies
  - requests
  - enum
 
+
  * python 3
 This library requires the following dependencies
  - elasticsearch

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,13 @@ Install using pip::
 
 Requirements
 ============
-__python 2__
+ * python 2
 This library requires the following dependencies
  - elasticsearch
  - requests
  - enum
 
-__python 3__
+ * python 3
 This library requires the following dependencies
  - elasticsearch
  - requests

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ It is also very easy to integrate the handler to `Django <https://www.djangoproj
 better, at DEBUG level django logs information such as how long it takes for DB connections to return so
 they can be plotted on Kibana, or the SQL statements that Django executed. ::
 
-    from cmreshandler.cmreshandler import CMRESHandler
+    from cmreslogging.handlers import CMRESHandler
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,

--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -4,6 +4,7 @@
 import logging
 import datetime
 import socket
+import copy
 from threading import Timer
 from enum import Enum
 from elasticsearch import helpers as eshelpers
@@ -56,11 +57,11 @@ class CMRESHandler(logging.Handler):
     __DEFAULT_AUTH_TYPE = AuthType.NO_AUTH
     __DEFAULT_INDEX_FREQUENCY = IndexNameFrequency.DAILY
     __DEFAULT_BUFFER_SIZE = 1000
-    __DEFAULT_FLUSH_FREQUENCY_IN_SEC = 1
+    __DEFAULT_FLUSH_FREQ_INSEC = 1
     __DEFAULT_ADDITIONAL_FIELDS = {}
     __DEFAULT_ES_INDEX_NAME = 'python_logger'
     __DEFAULT_ES_DOC_TYPE = 'python_log'
-    __DEFAULT_RAISE_ON_INDEX_EXCEPTIONS = False
+    __DEFAULT_RAISE_ON_EXCEPTION = False
     __DEFAULT_TIMESTAMP_FIELD_NAME = "timestamp"
 
     __LOGGING_FILTER_FIELDS = ['msecs',
@@ -116,12 +117,12 @@ class CMRESHandler(logging.Handler):
                  use_ssl=__DEFAULT_USE_SSL,
                  verify_ssl=__DEFAULT_VERIFY_SSL,
                  buffer_size=__DEFAULT_BUFFER_SIZE,
-                 flush_frequency_in_sec=__DEFAULT_FLUSH_FREQUENCY_IN_SEC,
+                 flush_frequency_in_sec=__DEFAULT_FLUSH_FREQ_INSEC,
                  es_index_name=__DEFAULT_ES_INDEX_NAME,
                  index_name_frequency=__DEFAULT_INDEX_FREQUENCY,
                  es_doc_type=__DEFAULT_ES_DOC_TYPE,
                  es_additional_fields=__DEFAULT_ADDITIONAL_FIELDS,
-                 raise_on_indexing_exceptions=__DEFAULT_RAISE_ON_INDEX_EXCEPTIONS,
+                 raise_on_indexing_exceptions=__DEFAULT_RAISE_ON_EXCEPTION,
                  default_timestamp_field_name=__DEFAULT_TIMESTAMP_FIELD_NAME):
         """ Handler constructor
 
@@ -154,7 +155,7 @@ class CMRESHandler(logging.Handler):
         """
         logging.Handler.__init__(self)
 
-        self.hosts = hosts
+        self.hosts = copy.deepcopy(hosts)
         self.auth_details = auth_details
         self.auth_type = auth_type
         self.use_ssl = use_ssl
@@ -164,7 +165,7 @@ class CMRESHandler(logging.Handler):
         self.es_index_name = es_index_name
         self.index_name_frequency = index_name_frequency
         self.es_doc_type = es_doc_type
-        self.es_additional_fields = es_additional_fields.copy()
+        self.es_additional_fields = copy.deepcopy(es_additional_fields)
         self.es_additional_fields.update({'host': socket.gethostname(),
                                           'host_ip': socket.gethostbyname(socket.gethostname())})
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+elasticsearch==5.1.0
+enum==0.4.6

--- a/requirements/requirements_py27.txt
+++ b/requirements/requirements_py27.txt
@@ -1,0 +1,3 @@
+elasticsearch==5.1.0
+requests==2.12.4
+enum==0.4.6

--- a/requirements/requirements_py36.txt
+++ b/requirements/requirements_py36.txt
@@ -1,2 +1,2 @@
 elasticsearch==5.1.0
-enum==0.4.6
+requests==2.12.4

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+import sys
 
 here = path.abspath(path.dirname(__file__))
 
@@ -16,13 +17,24 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+dependencies = [
+    'elasticsearch',
+    'requests'
+]
+
+# If python version is above 3.4 (built in enums supported enums)
+if sys.version_info <= (3,4):
+    dependencies.append('enum')
+
+print("List of dependencies : {0}".format(str(dependencies)))
+
 setup(
     name='CMRESHandler',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0a2',
+    version='1.0.0b1',
 
     description='Elasticsearch Log handler for the logging library',
     long_description=long_description,
@@ -42,7 +54,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
@@ -56,6 +68,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?
@@ -73,10 +86,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['elasticsearch',
-                      'requests',
-                      'enum',
-                      'requests-kerberos'],
+    install_requires=dependencies,
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,15 @@
+sonar.projectKey=cmr.python:python-elasticsearch-logger
+sonar.projectName=Python Elasticsearch Logger
+sonar.projectVersion=1.0.0.0b1
+sonar.verbose=DEBUG
+sonar.language=py
+sonar.sources=cmreslogging
+sonar.tests=tests
+sonar.python.coverage.reportPath=coverage.xml
+sonar.sourceEncoding=UTF-8
+
+
+
+
+
+

--- a/tests/test_cmreshandler.py
+++ b/tests/test_cmreshandler.py
@@ -32,9 +32,10 @@ class CMRESHandlerTestCase(unittest.TestCase):
         handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="pythontest",
-                               use_ssl=False)
+                               use_ssl=False,
+                               raise_on_indexing_exceptions=True)
         es_test_server_is_up = handler.test_es_source()
-        self.assertEquals(True, es_test_server_is_up)
+        self.assertEqual(True, es_test_server_is_up)
 
     def test_buffered_log_insertion_flushed_when_buffer_full(self):
         handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
@@ -43,18 +44,19 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                buffer_size=2,
                                flush_frequency_in_sec=1000,
                                es_index_name="pythontest",
-                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
+                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'},
+                               raise_on_indexing_exceptions=True)
 
         es_test_server_is_up = handler.test_es_source()
         self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
-        self.assertEquals(True, es_test_server_is_up)
+        self.assertEqual(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
         log.setLevel(logging.DEBUG)
         log.addHandler(handler)
         log.warning("First Message")
         log.info("Seccond Message")
-        self.assertEquals(0, len(handler._buffer))
+        self.assertEqual(0, len(handler._buffer))
         handler.close()
 
     def test_es_log_extra_argument_insertion(self):
@@ -63,22 +65,23 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                use_ssl=False,
                                es_index_name="pythontest",
-                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
+                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'},
+                               raise_on_indexing_exceptions=True)
 
         es_test_server_is_up = handler.test_es_source()
         self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
-        self.assertEquals(True, es_test_server_is_up)
+        self.assertEqual(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
         log.addHandler(handler)
         log.warning("Extra arguments Message", extra={"Arg1": 300, "Arg2": 400})
-        self.assertEquals(1, len(handler._buffer))
-        self.assertEquals(handler._buffer[0]['Arg1'], 300)
-        self.assertEquals(handler._buffer[0]['Arg2'], 400)
-        self.assertEquals(handler._buffer[0]['App'], 'Test')
-        self.assertEquals(handler._buffer[0]['Environment'], 'Dev')
+        self.assertEqual(1, len(handler._buffer))
+        self.assertEqual(handler._buffer[0]['Arg1'], 300)
+        self.assertEqual(handler._buffer[0]['Arg2'], 400)
+        self.assertEqual(handler._buffer[0]['App'], 'Test')
+        self.assertEqual(handler._buffer[0]['Environment'], 'Dev')
         handler.flush()
-        self.assertEquals(0, len(handler._buffer))
+        self.assertEqual(0, len(handler._buffer))
 
     def test_buffered_log_insertion_after_interval_expired(self):
         handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
@@ -86,22 +89,23 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                flush_frequency_in_sec=0.1,
                                es_index_name="pythontest",
-                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'})
+                               es_additional_fields={'App': 'Test', 'Environment': 'Dev'},
+                               raise_on_indexing_exceptions=True)
 
         es_test_server_is_up = handler.test_es_source()
         self.log.info("ES services status is:  {0!s}".format(es_test_server_is_up))
-        self.assertEquals(True, es_test_server_is_up)
+        self.assertEqual(True, es_test_server_is_up)
 
         log = logging.getLogger("PythonTest")
         log.addHandler(handler)
         log.warning("Extra arguments Message", extra={"Arg1": 300, "Arg2": 400})
-        self.assertEquals(1, len(handler._buffer))
-        self.assertEquals(handler._buffer[0]['Arg1'], 300)
-        self.assertEquals(handler._buffer[0]['Arg2'], 400)
-        self.assertEquals(handler._buffer[0]['App'], 'Test')
-        self.assertEquals(handler._buffer[0]['Environment'], 'Dev')
+        self.assertEqual(1, len(handler._buffer))
+        self.assertEqual(handler._buffer[0]['Arg1'], 300)
+        self.assertEqual(handler._buffer[0]['Arg2'], 400)
+        self.assertEqual(handler._buffer[0]['App'], 'Test')
+        self.assertEqual(handler._buffer[0]['Environment'], 'Dev')
         time.sleep(1)
-        self.assertEquals(0, len(handler._buffer))
+        self.assertEqual(0, len(handler._buffer))
 
     def test_fast_insertion_of_hundred_logs(self):
         handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
@@ -109,14 +113,62 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                buffer_size=500,
                                flush_frequency_in_sec=0.5,
-                               es_index_name="pythontest")
+                               es_index_name="pythontest",
+                               raise_on_indexing_exceptions=True)
         log = logging.getLogger("PythonTest")
         log.setLevel(logging.DEBUG)
         log.addHandler(handler)
         for i in range(100):
             log.info("Logging line {0:d}".format(i), extra={'LineNum': i})
         handler.flush()
-        self.assertEquals(0, len(handler._buffer))
+        self.assertEqual(0, len(handler._buffer))
+
+    def test_index_name_frequency_functions(self):
+        index_name = "pythontest"
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+                               auth_type=CMRESHandler.AuthType.NO_AUTH,
+                               es_index_name=index_name,
+                               use_ssl=False,
+                               index_name_frequency=CMRESHandler.IndexNameFrequency.DAILY,
+                               raise_on_indexing_exceptions=True)
+        self.assertEquals(
+            handler._index_name_func.__func__(index_name),
+            CMRESHandler._get_daily_index_name(index_name)
+        )
+
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+                               auth_type=CMRESHandler.AuthType.NO_AUTH,
+                               es_index_name=index_name,
+                               use_ssl=False,
+                               index_name_frequency=CMRESHandler.IndexNameFrequency.WEEKLY,
+                               raise_on_indexing_exceptions=True)
+        self.assertEquals(
+            handler._index_name_func.__func__(index_name),
+            CMRESHandler._get_weekly_index_name(index_name)
+        )
+
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+                               auth_type=CMRESHandler.AuthType.NO_AUTH,
+                               es_index_name=index_name,
+                               use_ssl=False,
+                               index_name_frequency=CMRESHandler.IndexNameFrequency.MONTHLY,
+                               raise_on_indexing_exceptions=True)
+        self.assertEquals(
+            handler._index_name_func.__func__(index_name),
+            CMRESHandler._get_monthly_index_name(index_name)
+        )
+
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+                               auth_type=CMRESHandler.AuthType.NO_AUTH,
+                               es_index_name=index_name,
+                               use_ssl=False,
+                               index_name_frequency=CMRESHandler.IndexNameFrequency.YEARLY,
+                               raise_on_indexing_exceptions=True)
+        self.assertEquals(
+            handler._index_name_func.__func__(index_name),
+            CMRESHandler._get_yearly_index_name(index_name)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cmreshandler.py
+++ b/tests/test_cmreshandler.py
@@ -131,7 +131,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.DAILY,
                                raise_on_indexing_exceptions=True)
-        self.assertEquals(
+        self.assertEqual(
             handler._index_name_func.__func__(index_name),
             CMRESHandler._get_daily_index_name(index_name)
         )
@@ -142,7 +142,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.WEEKLY,
                                raise_on_indexing_exceptions=True)
-        self.assertEquals(
+        self.assertEqual(
             handler._index_name_func.__func__(index_name),
             CMRESHandler._get_weekly_index_name(index_name)
         )
@@ -153,7 +153,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.MONTHLY,
                                raise_on_indexing_exceptions=True)
-        self.assertEquals(
+        self.assertEqual(
             handler._index_name_func.__func__(index_name),
             CMRESHandler._get_monthly_index_name(index_name)
         )
@@ -164,7 +164,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
                                use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.YEARLY,
                                raise_on_indexing_exceptions=True)
-        self.assertEquals(
+        self.assertEqual(
             handler._index_name_func.__func__(index_name),
             CMRESHandler._get_yearly_index_name(index_name)
         )

--- a/tests/test_cmreshandler.py
+++ b/tests/test_cmreshandler.py
@@ -103,7 +103,7 @@ class CMRESHandlerTestCase(unittest.TestCase):
         time.sleep(1)
         self.assertEquals(0, len(handler._buffer))
 
-    def test_fast_insertion_of_thousands_logs(self):
+    def test_fast_insertion_of_hundred_logs(self):
         handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                use_ssl=False,
@@ -113,11 +113,10 @@ class CMRESHandlerTestCase(unittest.TestCase):
         log = logging.getLogger("PythonTest")
         log.setLevel(logging.DEBUG)
         log.addHandler(handler)
-        for i in range(1000):
+        for i in range(100):
             log.info("Logging line {0:d}".format(i), extra={'LineNum': i})
         handler.flush()
         self.assertEquals(0, len(handler._buffer))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 commands =
     python setup.py check -m -r -s
     flake8 --max-line-length=120 cmreslogging/
-    #pylint ./cmreslogging -r n --files-output=y --msg-template=\"\{path\}:\{line\}: [\{msg_id}(\{symbol\}), \{obj\}] \{msg\}\"
+    #pylint ./cmreslogging -r n --files-output=y '--msg-template="\{path\}:\{line\}: [\{msg_id\}(\{symbol\}), \{obj\}] \{msg\}"'
     coverage erase
     coverage run --source=./cmreslogging --branch tests/test_cmreshandler.py
     coverage xml -i

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,8 @@ deps =
     flake8
     pytest
     coverage
-    elasticsearch
-    enum
 commands =
-    {py27,py36}: python setup.py check -m -r -s
+    python setup.py check -m -r -s
     flake8 --max-line-length=120 cmreslogging/
     coverage run --source=./cmreslogging --branch tests/test_cmreshandler.py
     coverage html

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist = py{27}
+envlist = {py27,py36}
 
 [testenv]
 basepython =
     py27: python2.7
+    py36: python3.6
 deps =
     check-manifest
     docutils
-    {py27}: readme_renderer
+    {py27,py36}: readme_renderer
     flake8
     pytest
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,17 @@ deps =
     check-manifest
     docutils
     {py27}: readme_renderer
+    pylint
     flake8
     pytest
     coverage
 commands =
     python setup.py check -m -r -s
     flake8 --max-line-length=120 cmreslogging/
+    #pylint ./cmreslogging -r n --files-output=y --msg-template=\"\{path\}:\{line\}: [\{msg_id}(\{symbol\}), \{obj\}] \{msg\}\"
+    coverage erase
     coverage run --source=./cmreslogging --branch tests/test_cmreshandler.py
+    coverage xml -i
     coverage html
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,25 @@
 envlist = {py27,py36}
 
 [testenv]
+passenv =
+    TEST_ES_SERVER
+    TEST_ES_PORT
 basepython =
     py27: python2.7
     py36: python3.6
 deps =
     check-manifest
     docutils
-    {py27,py36}: readme_renderer
+    {py27}: readme_renderer
     flake8
     pytest
     coverage
+    elasticsearch
+    enum
 commands =
-    {py27}: python setup.py check -m -r -s
-    flake8 --max-line-length=120 cmreshandler/
-    #python tests/test_cmreshandler.py
-    coverage run --source=./cmreshandler --branch tests/test_cmreshandler.py
+    {py27,py36}: python setup.py check -m -r -s
+    flake8 --max-line-length=120 cmreslogging/
+    coverage run --source=./cmreslogging --branch tests/test_cmreshandler.py
     coverage html
 
 [flake8]


### PR DESCRIPTION
Added extra functionality to create daily, weekly, monthly, yearly indices
Supports python2 and 3 (starting with 3.4 as a dependency from Enum)
Changed a few map operations to iterators to save some potential memory
Clients on basic or no authentications are reused. Kerberos clients are still re-generated in each flush cycle to request new valid token and avoid tokens expiring.