### PR TITLE
Schedule flush later

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,11 @@ Additional requirements for Kerberos support
 Additionally, the package support optionally kerberos authentication by adding the following dependecy
  - requests-kerberos
 
+ Additional requirements for AWS IAM user authentication (request signing)
+============================================
+Additionally, the package support optionally AWS IAM user authentication by adding the following dependecy
+ - requests-aws4auth
+
 Using the handler in  your program
 ==================================
 To initialise and create the handler, just add the handler to your logger as follow ::
@@ -94,6 +99,9 @@ The constructors takes the following parameters:
 
  - auth_type: The authentication currently support CMRESHandler.AuthType = NO_AUTH, BASIC_AUTH, KERBEROS_AUTH
  - auth_details: When CMRESHandler.AuthType.BASIC_AUTH is used this argument must contain a tuple of string with the user and password that will be used to authenticate against the Elasticsearch servers, for example ('User','Password')
+ - aws_access_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS key id of the  the AWS IAM user
+ - aws_secret_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS secret key of the  the AWS IAM user
+ - aws_region: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS region of the  the AWS Elasticsearch servers, for example ``'us-east'``
  - use_ssl: A boolean that defines if the communications should use SSL encrypted communication
  - verify_ssl: A boolean that defines if the SSL certificates are validated or not
  - buffer_size: An int, Once this size is reached on the internal buffer results are flushed into ES

--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,8 @@ Additional requirements for Kerberos support
 Additionally, the package support optionally kerberos authentication by adding the following dependecy
  - requests-kerberos
 
- Additional requirements for AWS IAM user authentication (request signing)
-============================================
+Additional requirements for AWS IAM user authentication (request signing)
+=========================================================================
 Additionally, the package support optionally AWS IAM user authentication by adding the following dependecy
  - requests-aws4auth
 

--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -139,9 +139,9 @@ class CMRESHandler(logging.Handler):
                     a tuple of string with the user and password that will be used to authenticate against
                     the Elasticsearch servers, for example```('User','Password')
         :param aws_access_key: When ```CMRESHandler.AuthType.AWS_SIGNED_AUTH``` is used this argument must contain
-                    the AWS key id of the  the AWS IAM user, for example```'12345
+                    the AWS key id of the  the AWS IAM user
         :param aws_secret_key: When ```CMRESHandler.AuthType.AWS_SIGNED_AUTH``` is used this argument must contain
-                    the AWS secret key of the  the AWS IAM user, for example```'5678'
+                    the AWS secret key of the  the AWS IAM user
         :param aws_region: When ```CMRESHandler.AuthType.AWS_SIGNED_AUTH``` is used this argument must contain
                     the AWS region of the  the AWS Elasticsearch servers, for example```'us-east'
         :param auth_type: The authentication type to be used in the connection ```CMRESHandler.AuthType```
@@ -231,15 +231,13 @@ class CMRESHandler(logging.Handler):
         if self.auth_type == CMRESHandler.AuthType.AWS_SIGNED_AUTH:
             from requests_aws4auth import AWS4Auth
             awsauth = AWS4Auth(self.aws_access_key, self.aws_secret_key, self.aws_region, 'es')
-            es = Elasticsearch(
+            return Elasticsearch(
                 hosts=self.hosts,
                 http_auth=awsauth,
                 use_ssl=self.use_ssl,
                 verify_certs=True,
                 connection_class=RequestsHttpConnection
             )
-            return es
-
 
         raise ValueError("Authentication method not supported")
 


### PR DESCRIPTION
( This builds upon my previous pull request that adds AWS elasticsearch logging, so I guess it should be reviewed afterwards. )

Instead of scheduling the flush "recursively", with this pull request, a flush will be scheduled under two conditions:
    1. No flush is scheduled yet, and
    2. there is actually something in the buffer that needs to be flushed.

This has two advantages:
    1. Flushes only happen if something is in the buffer. 
    2. If the process is forked after the `__init__` is called, the logging handler is copied into each process. Before, it would flush the buffer only in the original process and not log in any forked processes. Now, it will be logging in all processes. I noticed that I needed this for example for django_q.

