### PR TITLE
WIP: Cast log record value to string in order to avoid serialization issues

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -328,7 +328,7 @@ class CMRESHandler(logging.Handler):
         rec = self.es_additional_fields.copy()
         for key, value in record.__dict__.items():
             if key not in CMRESHandler.__LOGGING_FILTER_FIELDS:
-                rec[key] = "" if value is None else value
+                rec[key] = "" if value is None else str(value)
         rec[self.default_timestamp_field_name] = self.__get_es_datetime_str(record.created)
         with self._buffer_lock:
             self._buffer.append(rec)


### PR DESCRIPTION
The `eshelpers.bulk method was giving me a Serialization error for some log records. Casting the log record values to string beforehand should solve this. However I am not sure yet if this is really fixing the issue at its core.

And of course it breaks the tests because everything is a string now...