### PR TITLE
Simplify CMRESSerializer code

### DIFF
--- a/cmreslogging/serializers.py
+++ b/cmreslogging/serializers.py
@@ -1,8 +1,5 @@
 """ JSON serializer for Elasticsearch use
 """
-from datetime import date, datetime
-from decimal import Decimal
-
 from elasticsearch.serializer import JSONSerializer
 
 
@@ -19,11 +16,7 @@ class CMRESSerializer(JSONSerializer):
 
         :params data: The data to serialize before sending it to elastic search
         """
-        result = None
-        if isinstance(data, (date, datetime)):
-            result = data.isoformat()
-        elif isinstance(data, Decimal):
-            result = float(data)
-        else:
-            result = str(data)
-        return result
+        try:
+            return super(CMRESSerializer, self).default(data)
+        except TypeError:
+            return str(data)


### PR DESCRIPTION
By calling into super, we can avoid duplicating code from elasticsearch.
