### PR TITLE
Set localhost if gethostbyname() is un-resolvable

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -194,7 +194,7 @@ class CMRESHandler(logging.Handler):
 
             self.es_additional_fields.update({'host': socket.gethostname(),
                                               'host_ip': socket.gethostbyname(socket.gethostname())})
-        except:
+        except Exception:
             self.es_additional_fields.update({'host': 'localhost',
                                               'host_ip': '127.0.0.1'})
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions

--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -190,8 +190,13 @@ class CMRESHandler(logging.Handler):
         self.index_name_frequency = index_name_frequency
         self.es_doc_type = es_doc_type
         self.es_additional_fields = es_additional_fields.copy()
-        self.es_additional_fields.update({'host': socket.gethostname(),
-                                          'host_ip': socket.gethostbyname(socket.gethostname())})
+        try:
+
+            self.es_additional_fields.update({'host': socket.gethostname(),
+                                              'host_ip': socket.gethostbyname(socket.gethostname())})
+        except:
+            self.es_additional_fields.update({'host': 'localhost',
+                                              'host_ip': '127.0.0.1'})
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions
         self.default_timestamp_field_name = default_timestamp_field_name
 


### PR DESCRIPTION
… the 'host' can't be resolved either via DNS or via local-hosts file. Setting 'localhost' under such cases.