### PR TITLE
Should `msg`  also be included in filter fields?

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -79,6 +79,7 @@ class CMRESHandler(logging.Handler):
     __LOGGING_FILTER_FIELDS = ['msecs',
                                'relativeCreated',
                                'levelno',
+                               'msg',
                                'created']
 
     @staticmethod


### PR DESCRIPTION
`msg` is not included in logging.Formatter documents, and will be included in the elasticsearch message body, as you're not excluding it here. If you using this handler just for one specific logger statement, it is fine. If you want to apply it to global logger, and there will be various types of `msg` coexisted, then elasticsearch will drop some messages because of that.