### PR TITLE
Fix issue with dictionary logging

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -328,6 +328,8 @@ class CMRESHandler(logging.Handler):
         rec = self.es_additional_fields.copy()
         for key, value in record.__dict__.items():
             if key not in CMRESHandler.__LOGGING_FILTER_FIELDS:
+                if key == "args":
+                    value = tuple(str(arg) for arg in value)
                 rec[key] = "" if value is None else value
         rec[self.default_timestamp_field_name] = self.__get_es_datetime_str(record.created)
         with self._buffer_lock:


### PR DESCRIPTION
Elasticsearch failed at 'arg' field parsing if log function argument is a dictionary.
Example: logging.info("POST query: %s", {'any': 'dictionary'})
This fix enforces conversion of log arguments to strings.