### PR TITLE
Using environment marker for version on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,19 +22,13 @@ dependencies = [
     'requests'
 ]
 
-# If python version is above 3.4 (built in enums supported enums)
-if sys.version_info <= (3,4):
-    dependencies.append('enum')
-
-print("List of dependencies : {0}".format(str(dependencies)))
-
 setup(
     name='CMRESHandler',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.0.1',
 
     description='Elasticsearch Log handler for the logging library',
     long_description=long_description,
@@ -93,6 +87,9 @@ setup(
     # for example:
     # $ pip install -e .[dev,test]
     extras_require={
+        ':python_version<="3.4"': [
+            'enum'
+        ],
         'dev': ['check-manifest', 'six', 'pylint'],
         'test': ['coverage'],
     },


### PR DESCRIPTION
Currently the setup.py will check the Python version using `sys.version_info`.
That is not considered good practice and for example will not work with Poetry.
The recommendation is then to use [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers). See for example [this issue](https://github.com/sdispater/poetry/issues/844).