### PR TITLE
Fix installing via Poetry on python 3.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,10 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 dependencies = [
     'elasticsearch',
-    'requests'
+    'requests',
+    # If python version is above 3.4 (built in enums supported enums)
+    'enum; python_version <= "3.4"'
 ]
-
-# If python version is above 3.4 (built in enums supported enums)
-if sys.version_info <= (3,4):
-    dependencies.append('enum')
 
 print("List of dependencies : {0}".format(str(dependencies)))
 


### PR DESCRIPTION
When installing via [Poetry](https://python-poetry.org), the package enum is added to the package lock even though it cannot be installed for newer versions of python.

It seems to happen because the [pypi endpoint](https://pypi.org/pypi/CMRESHandler/1.0.0/json) returns enum as a dependency for all versions of python (under info/requires_dist).

I've fixed it by using an [environment marker](https://www.python.org/dev/peps/pep-0508/#environment-markers) to the enum dependency instead of calculating it in setup.py