### PR TITLE
Excludes "tests" from installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['dist', 'docs', 'build']),
+    packages=find_packages(exclude=['dist', 'docs', 'build', 'tests', 'tests.*']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
Currently the `tests` directory is installed as a package when using `pip`.