### PR TITLE
Custome ES records names

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -75,6 +75,7 @@ class CMRESHandler(logging.Handler):
     __DEFAULT_ES_DOC_TYPE = 'python_log'
     __DEFAULT_RAISE_ON_EXCEPTION = False
     __DEFAULT_TIMESTAMP_FIELD_NAME = "timestamp"
+    __DEFAULT_ES_RECORDS_MAPPING = {}
 
     __LOGGING_FILTER_FIELDS = ['msecs',
                                'relativeCreated',
@@ -138,7 +139,8 @@ class CMRESHandler(logging.Handler):
                  es_doc_type=__DEFAULT_ES_DOC_TYPE,
                  es_additional_fields=__DEFAULT_ADDITIONAL_FIELDS,
                  raise_on_indexing_exceptions=__DEFAULT_RAISE_ON_EXCEPTION,
-                 default_timestamp_field_name=__DEFAULT_TIMESTAMP_FIELD_NAME):
+                 default_timestamp_field_name=__DEFAULT_TIMESTAMP_FIELD_NAME,
+                 es_records_name_mapping_dict=__DEFAULT_ES_RECORDS_MAPPING):
         """ Handler constructor
 
         :param hosts: The list of hosts that elasticsearch clients will connect. The list can be provided
@@ -172,6 +174,8 @@ class CMRESHandler(logging.Handler):
                     to the logs, such the application, environment, etc.
         :param raise_on_indexing_exceptions: A boolean, True only for debugging purposes to raise exceptions
                     caused when
+        :param es_records_name_mapping_dict: A dictionary with records name mappings, as key is expected the old name and
+                    as value the wanted name in ES. {'old_name':'new_name'}
         :return: A ready to be used CMRESHandler.
         """
         logging.Handler.__init__(self)
@@ -194,6 +198,7 @@ class CMRESHandler(logging.Handler):
                                           'host_ip': socket.gethostbyname(socket.gethostname())})
         self.raise_on_indexing_exceptions = raise_on_indexing_exceptions
         self.default_timestamp_field_name = default_timestamp_field_name
+        self.es_records_name_mapping_dict = es_records_name_mapping_dict
 
         self._client = None
         self._buffer = []
@@ -328,9 +333,10 @@ class CMRESHandler(logging.Handler):
         rec = self.es_additional_fields.copy()
         for key, value in record.__dict__.items():
             if key not in CMRESHandler.__LOGGING_FILTER_FIELDS:
-                if key == "args":
-                    value = tuple(str(arg) for arg in value)
-                rec[key] = "" if value is None else value
+                if key in self.es_records_name_mapping_dict:
+                    rec[self.es_records_name_mapping_dict[key]] = "" if value is None else value
+                else:
+                    rec[key] = "" if value is None else value
         rec[self.default_timestamp_field_name] = self.__get_es_datetime_str(record.created)
         with self._buffer_lock:
             self._buffer.append(rec)


### PR DESCRIPTION
Add mapping dict to rename ES records fields. With this changes is possible to rename log records to the expected names for ES.
