### PR TITLE
set elasticsearch version to 7.17.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 dependencies = [
-    'elasticsearch',
+    'elasticsearch==7.17.9',
     'requests'
 ]
 


### PR DESCRIPTION
Version 8+ brakes functionality as RequestsHttpConnection is removed.

fixes:
- https://github.com/cmanaha/python-elasticsearch-logger/issues/91