### PR TITLE
Elasticsearch v8 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,14 +26,6 @@ Install using pip::
 
     pip install CMRESHandler
 
-Requirements Python 2
-=====================
-This library requires the following dependencies
- - elasticsearch
- - requests
- - enum
-
-
 Requirements Python 3
 =====================
 This library requires the following dependencies

--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,12 @@ This library requires the following dependencies
 
 Additional requirements for Kerberos support
 ============================================
-Additionally, the package support optionally kerberos authentication by adding the following dependecy
+Additionally, the package support optionally kerberos authentication by adding the following dependency
  - requests-kerberos
 
 Additional requirements for AWS IAM user authentication (request signing)
 =========================================================================
-Additionally, the package support optionally AWS IAM user authentication by adding the following dependecy
+Additionally, the package support optionally AWS IAM user authentication by adding the following dependency
  - requests-aws4auth
 
 Using the handler in  your program
@@ -55,7 +55,7 @@ Using the handler in  your program
 To initialise and create the handler, just add the handler to your logger as follow ::
 
     from cmreslogging.handlers import CMRESHandler
-    handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200}],
+    handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200, 'scheme': 'http'}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="my_python_index")
     log = logging.getLogger("PythonTest")
@@ -65,7 +65,7 @@ To initialise and create the handler, just add the handler to your logger as fol
 You can add fields upon initialisation, providing more data of the execution context ::
 
     from cmreslogging.handlers import CMRESHandler
-    handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200}],
+    handler = CMRESHandler(hosts=[{'host': 'localhost', 'port': 9200, 'scheme': 'http'}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="my_python_index",
                                es_additional_fields={'App': 'MyAppName', 'Environment': 'Dev'})
@@ -95,9 +95,11 @@ Kibana on top of elasticsearch
 Initialisation parameters
 =========================
 The constructors takes the following parameters:
- - hosts:  The list of hosts that elasticsearch clients will connect, multiple hosts are allowed, for example ::
+  - hosts:  The list of hosts that elasticsearch clients will connect, multiple hosts are allowed.
+   Use ```'scheme'``` to determinate if use SSL (`use_ssl` is deprecated). To use SSL set ```'scheme': 'https'```, or if you don't need SSL Sset ```'scheme': 'http'```.
+   for example::
 
-    [{'host':'host1','port':9200}, {'host':'host2','port':9200}]
+    [{'host':'host1','port':9200, 'scheme': 'https'}, {'host':'host2','port':9200, 'scheme': 'http'}]
 
 
  - auth_type: The authentication currently support CMRESHandler.AuthType = NO_AUTH, BASIC_AUTH, KERBEROS_AUTH
@@ -105,7 +107,6 @@ The constructors takes the following parameters:
  - aws_access_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS key id of the  the AWS IAM user
  - aws_secret_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS secret key of the  the AWS IAM user
  - aws_region: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS region of the  the AWS Elasticsearch servers, for example ``'us-east'``
- - use_ssl: A boolean that defines if the communications should use SSL encrypted communication
  - verify_ssl: A boolean that defines if the SSL certificates are validated or not
  - buffer_size: An int, Once this size is reached on the internal buffer results are flushed into ES
  - flush_frequency_in_sec: A float representing how often and when the buffer will be flushed
@@ -139,7 +140,7 @@ they can be plotted on Kibana, or the SQL statements that Django executed. ::
             'elasticsearch': {
                 'level': 'DEBUG',
                 'class': 'cmreslogging.handlers.CMRESHandler',
-                'hosts': [{'host': 'localhost', 'port': 9200}],
+                'hosts': [{'host': 'localhost', 'port': 9200, 'scheme': 'http'}],
                 'es_index_name': 'my_python_app',
                 'es_additional_fields': {'App': 'Test', 'Environment': 'Dev'},
                 'auth_type': CMRESHandler.AuthType.NO_AUTH,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
-import sys
 
 here = path.abspath(path.dirname(__file__))
 
@@ -21,10 +20,6 @@ dependencies = [
     'elasticsearch',
     'requests'
 ]
-
-# If python version is above 3.4 (built in enums supported enums)
-if sys.version_info <= (3,4):
-    dependencies.append('enum')
 
 print("List of dependencies : {0}".format(str(dependencies)))
 
@@ -67,7 +62,6 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.0',
+    version='1.1.0',
 
     description='Elasticsearch Log handler for the logging library',
     long_description=long_description,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=cmr.python:python-elasticsearch-logger
 sonar.projectName=Python Elasticsearch Logger
-sonar.projectVersion=1.0.0b4
+sonar.projectVersion=1.1.0
 sonar.verbose=DEBUG
 sonar.language=py
 sonar.sources=cmreslogging

--- a/tests/test_cmreshandler.py
+++ b/tests/test_cmreshandler.py
@@ -3,6 +3,7 @@ import logging
 import time
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('.'))
 from cmreslogging.handlers import CMRESHandler
 
@@ -10,15 +11,20 @@ from cmreslogging.handlers import CMRESHandler
 class CMRESHandlerTestCase(unittest.TestCase):
     DEFAULT_ES_SERVER = 'localhost'
     DEFAULT_ES_PORT = 9200
+    DEFAULT_ES_SSL_SCHEME = 'http'
 
     def getESHost(self):
-        return os.getenv('TEST_ES_SERVER',CMRESHandlerTestCase.DEFAULT_ES_SERVER)
+        return os.getenv('TEST_ES_SERVER', CMRESHandlerTestCase.DEFAULT_ES_SERVER)
 
     def getESPort(self):
         try:
-            return int(os.getenv('TEST_ES_PORT',CMRESHandlerTestCase.DEFAULT_ES_PORT))
+            return int(os.getenv('TEST_ES_PORT', CMRESHandlerTestCase.DEFAULT_ES_PORT))
         except ValueError:
             return CMRESHandlerTestCase.DEFAULT_ES_PORT
+
+    @staticmethod
+    def get_ES_scheme():
+        return os.getenv('TEST_ES_SSL_SCHEME', CMRESHandlerTestCase.DEFAULT_ES_SSL_SCHEME)
 
     def setUp(self):
         self.log = logging.getLogger("MyTestCase")
@@ -29,18 +35,20 @@ class CMRESHandlerTestCase(unittest.TestCase):
         del self.log
 
     def test_ping(self):
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name="pythontest",
-                               use_ssl=False,
                                raise_on_indexing_exceptions=True)
         es_test_server_is_up = handler.test_es_source()
         self.assertEqual(True, es_test_server_is_up)
 
     def test_buffered_log_insertion_flushed_when_buffer_full(self):
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
-                               use_ssl=False,
                                buffer_size=2,
                                flush_frequency_in_sec=1000,
                                es_index_name="pythontest",
@@ -61,9 +69,10 @@ class CMRESHandlerTestCase(unittest.TestCase):
 
     def test_es_log_extra_argument_insertion(self):
         self.log.info("About to test elasticsearch insertion")
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
-                               use_ssl=False,
                                es_index_name="pythontest",
                                es_additional_fields={'App': 'Test', 'Environment': 'Dev'},
                                raise_on_indexing_exceptions=True)
@@ -84,9 +93,10 @@ class CMRESHandlerTestCase(unittest.TestCase):
         self.assertEqual(0, len(handler._buffer))
 
     def test_buffered_log_insertion_after_interval_expired(self):
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
-                               use_ssl=False,
                                flush_frequency_in_sec=0.1,
                                es_index_name="pythontest",
                                es_additional_fields={'App': 'Test', 'Environment': 'Dev'},
@@ -108,9 +118,10 @@ class CMRESHandlerTestCase(unittest.TestCase):
         self.assertEqual(0, len(handler._buffer))
 
     def test_fast_insertion_of_hundred_logs(self):
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
-                               use_ssl=False,
                                buffer_size=500,
                                flush_frequency_in_sec=0.5,
                                es_index_name="pythontest",
@@ -125,10 +136,11 @@ class CMRESHandlerTestCase(unittest.TestCase):
 
     def test_index_name_frequency_functions(self):
         index_name = "pythontest"
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name=index_name,
-                               use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.DAILY,
                                raise_on_indexing_exceptions=True)
         self.assertEqual(
@@ -136,10 +148,11 @@ class CMRESHandlerTestCase(unittest.TestCase):
             CMRESHandler._get_daily_index_name(index_name)
         )
 
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name=index_name,
-                               use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.WEEKLY,
                                raise_on_indexing_exceptions=True)
         self.assertEqual(
@@ -147,10 +160,11 @@ class CMRESHandlerTestCase(unittest.TestCase):
             CMRESHandler._get_weekly_index_name(index_name)
         )
 
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name=index_name,
-                               use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.MONTHLY,
                                raise_on_indexing_exceptions=True)
         self.assertEqual(
@@ -158,10 +172,11 @@ class CMRESHandlerTestCase(unittest.TestCase):
             CMRESHandler._get_monthly_index_name(index_name)
         )
 
-        handler = CMRESHandler(hosts=[{'host': self.getESHost(), 'port': self.getESPort()}],
+        handler = CMRESHandler(hosts=[{'host': self.getESHost(),
+                                       'port': self.getESPort(),
+                                       'scheme': self.get_ES_scheme()}],
                                auth_type=CMRESHandler.AuthType.NO_AUTH,
                                es_index_name=index_name,
-                               use_ssl=False,
                                index_name_frequency=CMRESHandler.IndexNameFrequency.YEARLY,
                                raise_on_indexing_exceptions=True)
         self.assertEqual(


### PR DESCRIPTION
Elasticsearch introduced braking change in version 8.0 by:
- removing RequestsHttpConnection
- removing use_ssl from Elasticsearch class
- supports only Python 3.6+

SSL is not set as 'scheme' string (http/https) in host dict.
Custom authorization need to set node_class to requests.

Current code is working with: 
elasticsearch      8.7.0

Reference:
https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/release-notes.html#_changed

Fixes:
https://github.com/cmanaha/python-elasticsearch-logger/issues/91