### PR TITLE
Add HttpNtlmAuth authorization method.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,11 @@ Additional requirements for Kerberos support
 Additionally, the package support optionally kerberos authentication by adding the following dependecy
  - requests-kerberos
 
+Additional requirements for NTLM support
+============================================
+Additionally, the package support optionally NTLM authentication by adding the following dependency
+ - requests-ntlm
+
 Additional requirements for AWS IAM user authentication (request signing)
 =========================================================================
 Additionally, the package support optionally AWS IAM user authentication by adding the following dependecy
@@ -100,8 +105,8 @@ The constructors takes the following parameters:
     [{'host':'host1','port':9200}, {'host':'host2','port':9200}]
 
 
- - auth_type: The authentication currently support CMRESHandler.AuthType = NO_AUTH, BASIC_AUTH, KERBEROS_AUTH
- - auth_details: When CMRESHandler.AuthType.BASIC_AUTH is used this argument must contain a tuple of string with the user and password that will be used to authenticate against the Elasticsearch servers, for example ('User','Password')
+ - auth_type: The authentication currently support CMRESHandler.AuthType = NO_AUTH, BASIC_AUTH, KERBEROS_AUTH, NTLM_AUTH
+ - auth_details: When ``CMRESHandler.AuthType.BASIC_AUTH`` or ``CMRESHandler.AuthType.NTLM_AUTH`` is used this argument must contain a tuple of string with the user and password that will be used to authenticate against the Elasticsearch servers, for example ('User','Password')
  - aws_access_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS key id of the  the AWS IAM user
  - aws_secret_key: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS secret key of the  the AWS IAM user
  - aws_region: When ``CMRESHandler.AuthType.AWS_SIGNED_AUTH`` is used this argument must contain the AWS region of the  the AWS Elasticsearch servers, for example ``'us-east'``


### PR DESCRIPTION
Add NLTM authorization method.
Needed to work in Docker and log in using Windows domain credentials.

Extends functionality of Kerberos support. User can provide specific user name and user password.